### PR TITLE
Added instrinsic velocity dispersion constraint

### DIFF
--- a/ifscube/parser.py
+++ b/ifscube/parser.py
@@ -446,11 +446,9 @@ class LineFitParser:
         # Remove key because it is not an argument of the linefit function
         self.fit_opts.pop('intrinsic_sigma_constr', None)
         self.fit_opts.pop('instrument_dispersion_angstrom', None)
-        print(fix_sigma0, instdisp)
 
         if fix_sigma0:
             instdisp_vel = instdisp * 299792.458 / np.array(self.feature_wl)
-        print(instdisp_vel)
 
         components = []
         for i in set(kg):

--- a/ifscube/spectools.py
+++ b/ifscube/spectools.py
@@ -768,3 +768,24 @@ class Constraints:
         d = dict(type='eq', fun=func)
 
         return d
+
+    def same_instrinsic_sigma(ha, hb, instr_quadratic_differece=0):
+        '''
+        Same instrinsic velocity dispersion.
+            sigma0_ha ** 2 = sigma0_hb ** 2
+            (sigma_ha ** 2 - inst_ha ** 2) = (sigma_hb ** 2 - inst_hb ** 2)
+            (sigma_ha ** 2 - sigma_hb ** 2) - (inst_ha ** 2 - inst_hb ** 2) = 0
+             
+
+        Parameters
+        ----------
+        instr_quadratic_differece: float
+            (instr_ha ** 2) - (instr_hb ** 2). In km/s.
+        '''
+        def func(x):
+            return x[ha]**2 - x[hb]**2 - instr_quadratic_differece
+
+        d = dict(type='eq', fun=func)
+
+        return d
+


### PR DESCRIPTION
- Now it is possible to constraint the velocity dispersion, based on its intrinsic value sigma0 = sqrt(sigma**2 - instr_disp ** 2).
- The instrument dispersion (in km/s) for each emission line is calculated from its value in angstroms.
- Instead of fixing the observed velocity dispersion, the option permits to fix the intrinsic velocity dispersion:
    sigma0_ha ** 2 = sigma0_hb ** 2
    (sigma_ha ** 2 - instdisp_ha ** 2) = (sigma_hb ** 2 - instdisp_hb ** 2)