### PR TITLE
Monte carlo

### DIFF
--- a/ifscube/modeling.py
+++ b/ifscube/modeling.py
@@ -1,3 +1,4 @@
+import copy
 import warnings
 from typing import Union, Iterable, Callable
 
@@ -430,14 +431,14 @@ class LineFit:
         assert self.solution is not None, 'Monte carlo uncertainties can only be evaluated after a successful fit.'
         assert not np.all(self.variance == 1.0), \
             'Cannot estimate uncertainties via Monte Carlo. The variance was not given.'
-        old_data = np.copy(self.data)
+        old_data = copy.deepcopy(self.data)
         solution_matrix = np.zeros((n_iterations,) + self.solution.shape)
         self.uncertainties = np.zeros_like(self.solution)
 
         for c in range(n_iterations):
             self.data = np.random.normal(old_data, np.sqrt(self.variance))
             self.fit(**self.fit_arguments)
-            solution_matrix[c] = np.copy(self.solution)
+            solution_matrix[c] = copy.deepcopy(self.solution)
         self.solution = solution_matrix.mean(axis=0)
         self.uncertainties = solution_matrix.std(axis=0)
         self.data = old_data

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -260,7 +260,7 @@ def test_monte_carlo():
     fit = full_fit()
     fit.optimize_fit(width=5.0)
     fit.fit()
-    fit.monte_carlo(3)
+    fit.monte_carlo(20)
     assert 1
 
 


### PR DESCRIPTION
Changed copy operation for the solutions of Monte Carlos runs. The previous version used numpy.copy, which makes a shallow copy of the self.solution attribute, while this pull request implements the copy.deepcopy method.