### PR TITLE
Fortran and Numpy

### DIFF
--- a/ifscube/modeling.py
+++ b/ifscube/modeling.py
@@ -50,7 +50,7 @@ class LineFit:
             self.function = elprofile.gauss_vel
             self.parameters_per_feature = 3
         elif function == 'gauss_hermite':
-            self.function = elprofile.gausshermitevel
+            self.function = elprofile.gauss_hermite_vel
             self.parameters_per_feature = 5
 
         self.solution = None

--- a/ifscube/modeling.py
+++ b/ifscube/modeling.py
@@ -47,7 +47,7 @@ class LineFit:
         self.constraints = []
 
         if function == 'gaussian':
-            self.function = elprofile.gaussvel
+            self.function = elprofile.gauss_vel
             self.parameters_per_feature = 3
         elif function == 'gauss_hermite':
             self.function = elprofile.gausshermitevel

--- a/ifscube/profiles.f90
+++ b/ifscube/profiles.f90
@@ -25,23 +25,37 @@ subroutine gauss(x, p, y, n, np)
 end
 
 
-subroutine gausshermite(x, p, y, n, np)
+subroutine gauss_hermite(x, p, y, n, np)
 
+    implicit none
     integer, parameter :: dp = selected_real_kind(15, 307)
-    real, parameter :: pi = 3.1415927, sq2 = sqrt(2.0), sq6 = sqrt(6.0)
-    real, parameter :: sq24 = sqrt(24.0), sq2pi = sqrt(2.0 * pi)
-    integer :: n, np
+    !f2py intent(hide), depend(x) :: n=len(x)
+    !f2py integer intent(hide), depend(p) :: np=len(p)
+    integer :: n
+    integer :: np
     integer :: i
-    real, dimension(0:np - 1), intent(in) :: p
-    real, dimension(0:n - 1), intent(in) :: x
-    real, dimension(0:n - 1) :: w, hh3, hh4, alphag, gh
-    real, dimension(0:n - 1), intent(out) :: y
-    real :: h3, h4
-    real :: a, l0, s
+    real(dp), parameter :: pi = 3.1415927
+    real(dp), parameter :: sq2 = sqrt(2.0)
+    real(dp), parameter :: sq6 = sqrt(6.0)
+    real(dp), parameter :: sq24 = sqrt(24.0)
+    real(dp), parameter :: sq2pi = sqrt(2.0 * pi)
+    real(dp), dimension(np), intent(in) :: p
+    real(dp), dimension(n), intent(in) :: x
+    real(dp), dimension(n), intent(out) :: y
+    real(dp), dimension(n) :: w
+    real(dp), dimension(n) :: h3
+    real(dp), dimension(n) :: hh3
+    real(dp), dimension(n) :: h4
+    real(dp), dimension(n) :: hh4
+    real(dp), dimension(n) :: alphag
+    real(dp), dimension(n) :: gh
+    real(dp) :: a
+    real(dp) :: l0
+    real(dp) :: s
 
     y(:) = 0.0
 
-    do i = 0, (np - 1), 5
+    do i = 1, np, 5
 
         a = p(i)
         l0 = p(i + 1)

--- a/ifscube/profiles.f90
+++ b/ifscube/profiles.f90
@@ -77,31 +77,40 @@ subroutine gauss_hermite(x, p, y, n, np)
 
 end
 
-subroutine gaussvel(x, rest_wl, p, y, n, np)
+subroutine gauss_vel(x, rest_wl, p, y, n, np, nwl)
 
-    real, parameter :: pi = 3.1415927, c = 299792.458
-    integer :: n, np, j, i
-    real, dimension(0:np - 1), intent(in) :: p
-    real, dimension(0:(np - 1) / 3), intent(in) :: rest_wl
-    real, dimension(0:n - 1), intent(in) :: x
-    real, dimension(0:n - 1), intent(out) :: y
-    real, dimension(0:n - 1) :: w, vel, fvel, lam_ratio
+    implicit none
+    integer, parameter :: dp = selected_real_kind(15, 307)
+    integer :: n
+    integer :: np
+    integer :: nwl
+    integer :: j
+    integer :: i
+    !f2py intent(hide), depend(x) :: n=len(x)
+    !f2py integer intent(hide), depend(p) :: np=len(p)
+    !f2py integer intent(hide), depend(rest_wl) :: np=len(rest_wl)
+    real(dp), parameter :: pi = 3.1415927
+    real(dp), parameter :: c = 299792.458
+    real(dp), dimension(np), intent(in) :: p
+    real(dp), dimension(nwl), intent(in) :: rest_wl
+    real(dp), dimension(n), intent(in) :: x
+    real(dp), dimension(n), intent(out) :: y
+    real(dp), dimension(n) :: w
+    real(dp), dimension(n) :: vel
+    real(dp), dimension(n) :: fvel
+    real(dp), dimension(n) :: lam_ratio
 
     vel(:) = 0.0
     y(:) = 0.0
 
-    j = 0
-    do i = 0, (np - 1), 3
+    j = 1
+    do i = 1, np, 3
         lam_ratio = (x / rest_wl(j)) ** 2
         vel = c * (lam_ratio - 1.0) / (lam_ratio + 1.0)
 
-        a = p(i)
-        v0 = p(i + 1)
-        s = p(i + 2)
-
-        w = (vel - v0) / s
+        w = -((vel - p(i + 1)) / p(i + 2))**2 / 2.0
         ! The observed flux density equals the emitted flux density divided by (1 + z)
-        fvel = a * exp(-w**2 / 2.0) / (1.0 + (vel / c))
+        fvel = p(i) * exp(w) / (1.0 + (vel / c))
 
         y = y + fvel
         j = j + 1
@@ -110,7 +119,7 @@ subroutine gaussvel(x, rest_wl, p, y, n, np)
 
 end
 
-subroutine gausshermitevel(x, rest_wl, p, y, n, np)
+subroutine gauss_hermite_vel(x, rest_wl, p, y, n, np)
 
     real, parameter :: pi = 3.1415927, c = 299792.458, sq2 = sqrt(2.0), sq6 = sqrt(6.0)
     real, parameter :: sq24 = sqrt(24.0), sq2pi = sqrt(2.0 * pi)

--- a/ifscube/profiles.f90
+++ b/ifscube/profiles.f90
@@ -119,24 +119,46 @@ subroutine gauss_vel(x, rest_wl, p, y, n, np, nwl)
 
 end
 
-subroutine gauss_hermite_vel(x, rest_wl, p, y, n, np)
+subroutine gauss_hermite_vel(x, rest_wl, p, y, n, np, nwl)
 
-    real, parameter :: pi = 3.1415927, c = 299792.458, sq2 = sqrt(2.0), sq6 = sqrt(6.0)
-    real, parameter :: sq24 = sqrt(24.0), sq2pi = sqrt(2.0 * pi)
-    integer :: n, np, i, j
-    real, dimension(0:(np - 1) / 5), intent(in) :: rest_wl
-    real, dimension(0:np - 1), intent(in) :: p
-    real, dimension(0:n - 1), intent(in) :: x
-    real, dimension(0:n - 1) :: w, hh3, hh4, alphag, vel, fvel, lam_ratio
-    real, dimension(0:n - 1), intent(out) :: y
-    real :: h3, h4
-    real :: a, l0, s
+    implicit none
+    integer, parameter :: dp = selected_real_kind(15, 307)
+    integer :: n=len(x)
+    integer :: np
+    integer :: nwl
+    integer :: j
+    integer :: i
+    !f2py intent(hide), depend(x) :: n=len(x)
+    !f2py integer intent(hide), depend(p) :: np=len(p)
+    !f2py integer intent(hide), depend(rest_wl) :: np=len(rest_wl)
+    real(dp), parameter :: pi = 3.1415927
+    real(dp), parameter :: sq2 = sqrt(2.0)
+    real(dp), parameter :: sq6 = sqrt(6.0)
+    real(dp), parameter :: sq24 = sqrt(24.0)
+    real(dp), parameter :: sq2pi = sqrt(2.0 * pi)
+    real(dp), parameter :: c = 299792.458
+    real(dp), dimension(nwl), intent(in) :: rest_wl
+    real(dp), dimension(np), intent(in) :: p
+    real(dp), dimension(n), intent(in) :: x
+    real(dp), dimension(n), intent(out) :: y
+    real(dp), dimension(n) :: w
+    real(dp), dimension(n) :: hh3
+    real(dp), dimension(n) :: hh4
+    real(dp), dimension(n) :: alphag
+    real(dp), dimension(n) :: vel
+    real(dp), dimension(n) :: fvel
+    real(dp), dimension(n) :: lam_ratio
+    real(dp) :: a
+    real(dp) :: v0
+    real(dp) :: s
+    real(dp) :: h3
+    real(dp) :: h4
 
     vel(:) = 0.0
     y(:) = 0.0
 
-    j = 0
-    do i = 0, (np - 1), 5
+    j = 1
+    do i = 1, np, 5
         ! Always use integer exponents, as it increases performance
         ! and has no impact on precision
         lam_ratio = (x / rest_wl(j))**2

--- a/ifscube/profiles.f90
+++ b/ifscube/profiles.f90
@@ -1,132 +1,142 @@
 subroutine gauss(x, p, y, n, np)
 
-    real, parameter :: pi=3.1415927
-    integer :: n, np
-    real, dimension(0:np-1), intent(in) :: p
-    real, dimension(0:n-1), intent(in) :: x
-    real, dimension(0:n-1), intent(out) :: y
+    implicit none
+    integer, parameter :: dp = selected_real_kind(15, 307)
+    integer :: n
+    integer :: np
+    integer :: i
+    !f2py intent(hide), depend(x) :: n=len(x)
+    !f2py integer intent(hide), depend(p) :: np=len(p)
+    real(dp), parameter :: pi = 3.1415927
+    real(dp), dimension(n), intent(in) :: x
+    real(dp), dimension(np), intent(in) :: p
+    real(dp), dimension(n), intent(out) :: y
+    real(dp), dimension(n) :: w
+    real(dp), dimension(n) :: g
 
-    y(:) = 0
+    y(:) = 0.0
 
-    do i=0, (np-1), 3
-        y = y + p(i)*exp(-(x-p(i+1))**2/2./p(i+2)**2)
+    do i = 1, np, 3
+        w = -((x - p(i + 1)) / p(i + 2))**2
+        g = p(i) * exp(w / 2.0)
+        y = y + g
     enddo
-    
-end
 
+end
 
 
 subroutine gausshermite(x, p, y, n, np)
 
-    real, parameter :: pi=3.1415927, sq2=sqrt(2.0), sq6=sqrt(6.0)
-    real, parameter :: sq24=sqrt(24.0), sq2pi=sqrt(2.0*pi)
+    integer, parameter :: dp = selected_real_kind(15, 307)
+    real, parameter :: pi = 3.1415927, sq2 = sqrt(2.0), sq6 = sqrt(6.0)
+    real, parameter :: sq24 = sqrt(24.0), sq2pi = sqrt(2.0 * pi)
     integer :: n, np
     integer :: i
-    real, dimension(0:np-1), intent(in) :: p
-    real, dimension(0:n-1), intent(in) :: x
-    real, dimension(0:n-1) :: w, hh3, hh4, alphag, gh
-    real, dimension(0:n-1), intent(out) :: y
+    real, dimension(0:np - 1), intent(in) :: p
+    real, dimension(0:n - 1), intent(in) :: x
+    real, dimension(0:n - 1) :: w, hh3, hh4, alphag, gh
+    real, dimension(0:n - 1), intent(out) :: y
     real :: h3, h4
     real :: a, l0, s
 
     y(:) = 0.0
- 
-    do i=0, (np-1), 5
+
+    do i = 0, (np - 1), 5
 
         a = p(i)
-        l0 = p(i+1)
-        s = p(i+2)
-        h3 = p(i+3)
-        h4 = p(i+4)
+        l0 = p(i + 1)
+        s = p(i + 2)
+        h3 = p(i + 3)
+        h4 = p(i + 4)
 
-        w = (x-l0)/s
+        w = (x - l0) / s
 
-        alphag = 1./sq2pi*exp(-w**2/2.)
-        hh3 = 1./sq6*(2.0*sq2*w**3-3.0*sq2*w)
-        hh4 = 1./sq24*(4.0*w**4-12.0*w**2+3.0)
+        alphag = 1. / sq2pi * exp(-w**2 / 2.)
+        hh3 = 1. / sq6 * (2.0 * sq2 * w**3 - 3.0 * sq2 * w)
+        hh4 = 1. / sq24 * (4.0 * w**4 - 12.0 * w**2 + 3.0)
 
-        gh = a*alphag/s*(1.0 + h3*hh3 + h4*hh4)
+        gh = a * alphag / s * (1.0 + h3 * hh3 + h4 * hh4)
 
         y = y + gh
 
     enddo
-    
+
 end
 
 subroutine gaussvel(x, rest_wl, p, y, n, np)
 
-    real, parameter :: pi=3.1415927, c=299792.458
+    real, parameter :: pi = 3.1415927, c = 299792.458
     integer :: n, np, j, i
-    real, dimension(0:np-1), intent(in) :: p
-    real, dimension(0:(np-1) / 3), intent(in) :: rest_wl
-    real, dimension(0:n-1), intent(in) :: x
-    real, dimension(0:n-1), intent(out) :: y
-    real, dimension(0:n-1) :: w, vel, fvel, lam_ratio
+    real, dimension(0:np - 1), intent(in) :: p
+    real, dimension(0:(np - 1) / 3), intent(in) :: rest_wl
+    real, dimension(0:n - 1), intent(in) :: x
+    real, dimension(0:n - 1), intent(out) :: y
+    real, dimension(0:n - 1) :: w, vel, fvel, lam_ratio
 
     vel(:) = 0.0
     y(:) = 0.0
 
     j = 0
-    do i=0, (np-1), 3
+    do i = 0, (np - 1), 3
         lam_ratio = (x / rest_wl(j)) ** 2
         vel = c * (lam_ratio - 1.0) / (lam_ratio + 1.0)
 
         a = p(i)
-        v0 = p(i+1)
-        s = p(i+2)
+        v0 = p(i + 1)
+        s = p(i + 2)
 
         w = (vel - v0) / s
         ! The observed flux density equals the emitted flux density divided by (1 + z)
         fvel = a * exp(-w**2 / 2.0) / (1.0 + (vel / c))
 
-        y = y + fvel 
+        y = y + fvel
         j = j + 1
 
     enddo
-    
+
 end
 
 subroutine gausshermitevel(x, rest_wl, p, y, n, np)
 
-    real, parameter :: pi=3.1415927, c=299792.458, sq2=sqrt(2.0), sq6=sqrt(6.0)
-    real, parameter :: sq24=sqrt(24.0), sq2pi=sqrt(2.0*pi)
+    real, parameter :: pi = 3.1415927, c = 299792.458, sq2 = sqrt(2.0), sq6 = sqrt(6.0)
+    real, parameter :: sq24 = sqrt(24.0), sq2pi = sqrt(2.0 * pi)
     integer :: n, np, i, j
-    real, dimension(0:(np-1) / 5), intent(in) :: rest_wl
-    real, dimension(0:np-1), intent(in) :: p
-    real, dimension(0:n-1), intent(in) :: x
-    real, dimension(0:n-1) :: w, hh3, hh4, alphag, vel, fvel, lam_ratio
-    real, dimension(0:n-1), intent(out) :: y
+    real, dimension(0:(np - 1) / 5), intent(in) :: rest_wl
+    real, dimension(0:np - 1), intent(in) :: p
+    real, dimension(0:n - 1), intent(in) :: x
+    real, dimension(0:n - 1) :: w, hh3, hh4, alphag, vel, fvel, lam_ratio
+    real, dimension(0:n - 1), intent(out) :: y
     real :: h3, h4
     real :: a, l0, s
 
     vel(:) = 0.0
     y(:) = 0.0
- 
-    j = 0 
-    do i=0, (np-1), 5
+
+    j = 0
+    do i = 0, (np - 1), 5
         ! Always use integer exponents, as it increases performance
         ! and has no impact on precision
         lam_ratio = (x / rest_wl(j))**2
         vel = c * (lam_ratio - 1.0) / (lam_ratio + 1.0)
 
         a = p(i)
-        v0 = p(i+1)
-        s = p(i+2)
-        h3 = p(i+3)
-        h4 = p(i+4)
+        v0 = p(i + 1)
+        s = p(i + 2)
+        h3 = p(i + 3)
+        h4 = p(i + 4)
 
-        w = (vel - v0)/s
+        w = (vel - v0) / s
 
         alphag = exp(-w**2 / 2.0)
-        hh3 = (2.0 * sq2 * w**3 - 3.0 * sq2*w) / sq6
+        hh3 = (2.0 * sq2 * w**3 - 3.0 * sq2 * w) / sq6
         hh4 = (4.0 * w**4 - 12.0 * w**2 + 3.0) / sq24
 
         ! The observed flux density equals the emitted flux density divided by (1 + z)
-        fvel = a * alphag * (1.0 + h3*hh3 + h4*hh4) / (1.0 + (vel / c))
+        fvel = a * alphag * (1.0 + h3 * hh3 + h4 * hh4) / (1.0 + (vel / c))
 
         y = y + fvel
         j = j + 1
 
     enddo
-    
+
 end

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 astropy==5.3.4
-matplotlib==3.8.0
-ppxf==8.2.6
-pytest==7.4.2
+matplotlib~=3.8.1
+ppxf~=9.0.1
+pytest~=7.4.3
 scipy==1.11.3
 tqdm==4.66.1
 vorbin==3.1.5
+numpy~=1.26.0

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -29,3 +29,11 @@ def test_flux_conservation_gaussvel():
 
 def test_flux_conservation_gausshermitevel():
     flux_conservation(fun=elprofile.gausshermitevel)
+
+
+def test_gauss():
+    x = np.linspace(start=-10, stop=10, num=11)
+    p = np.array([1.0, 0.0, 3.0, 2.0, 2.0, 1.0])
+    y = elprofile.gauss(x=x, p=p)
+    expected = 1.0 + (2.0 * np.exp(-(2.0 ** 2) / 2.0))
+    assert y[5] == expected

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -5,7 +5,7 @@ from ifscube import elprofile
 
 
 def flux_conservation(fun):
-    x = np.linspace(4000, 10000, 6000)
+    x = np.linspace(start=4000, stop=10000, num=6000)
     rest_wl = 7000
     v = 10000
     p_blue = [1, -v, 3000]
@@ -23,12 +23,12 @@ def flux_conservation(fun):
     assert ((flux_blue / flux_red) - 1.0) < 1e-8
 
 
-def test_flux_conservation_gaussvel():
-    flux_conservation(fun=elprofile.gaussvel)
+def test_flux_conservation_gauss_vel():
+    flux_conservation(fun=elprofile.gauss_vel)
 
 
-def test_flux_conservation_gausshermitevel():
-    flux_conservation(fun=elprofile.gausshermitevel)
+def test_flux_conservation_gauss_hermite_vel():
+    flux_conservation(fun=elprofile.gauss_hermite_vel)
 
 
 def test_gauss():
@@ -50,4 +50,12 @@ def test_gauss_hermite_asymmetry():
     x = np.linspace(start=-10, stop=10, num=11)
     p = np.array([1.0, 0.0, 3.0, 0.2, 0.0])
     y = elprofile.gauss_hermite(x=x, p=p)
+    assert y[4] > y[6]
+
+
+def test_gauss_vel():
+    x = np.linspace(start=6552.8, stop=6572.80, num=11)
+    p = np.array([1.0, 0.0, 100.0])
+    rest_wavelength = np.array([6562.80, 6562.80])
+    y = elprofile.gauss_vel(x=x, rest_wl=rest_wavelength, p=p)
     assert y[4] > y[6]

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -10,7 +10,7 @@ def flux_conservation(fun):
     v = 10000
     p_blue = [1, -v, 3000]
     p_red = [1, v, 3000]
-    if fun == elprofile.gausshermitevel:
+    if fun == elprofile.gauss_hermite_vel:
         p_blue += [.2, .2]
         p_red += [.2, .2]
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -56,6 +56,14 @@ def test_gauss_hermite_asymmetry():
 def test_gauss_vel():
     x = np.linspace(start=6552.8, stop=6572.80, num=11)
     p = np.array([1.0, 0.0, 100.0])
-    rest_wavelength = np.array([6562.80, 6562.80])
+    rest_wavelength = np.array([6562.80])
     y = elprofile.gauss_vel(x=x, rest_wl=rest_wavelength, p=p)
     assert y[4] > y[6]
+
+
+def test_gauss_hermite_vel():
+    x = np.linspace(start=6552.80, stop=6572.80, num=11)
+    p = np.array([1.0, 0.0, 100.0, 0.1, 0.1])
+    rest_wavelength = np.array([6562.80])
+    elprofile.gauss_hermite_vel(x=x, rest_wl=rest_wavelength, p=p)
+    assert True

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -37,3 +37,17 @@ def test_gauss():
     y = elprofile.gauss(x=x, p=p)
     expected = 1.0 + (2.0 * np.exp(-(2.0 ** 2) / 2.0))
     assert y[5] == expected
+
+
+def test_gauss_hermite_symmetry():
+    x = np.linspace(start=-10, stop=10, num=11)
+    p = np.array([1.0, 0.0, 3.0, 0.0, 0.2])
+    y = elprofile.gauss_hermite(x=x, p=p)
+    assert y[4] == y[6]
+
+
+def test_gauss_hermite_asymmetry():
+    x = np.linspace(start=-10, stop=10, num=11)
+    p = np.array([1.0, 0.0, 3.0, 0.2, 0.0])
+    y = elprofile.gauss_hermite(x=x, p=p)
+    assert y[4] > y[6]

--- a/tests/test_spectools.py
+++ b/tests/test_spectools.py
@@ -1,6 +1,6 @@
 import numpy as np
 from astropy import units
-from ifscube.elprofile import gaussvel
+from ifscube.elprofile import gauss_vel
 
 from ifscube import spectools
 
@@ -17,7 +17,7 @@ def test_velocity_width_oversample():
     p = np.array([1, -5000, 2000])
 
     wavelength = np.linspace(5000, 8000, 15000)
-    g = gaussvel(wavelength, rest_wavelength.value, p)
+    g = gauss_vel(wavelength, rest_wavelength.value, p)
     obs = np.random.normal(g, .05)
 
     vw_natural = spectools.velocity_width(
@@ -25,7 +25,7 @@ def test_velocity_width_oversample():
         fractional_pixels=True)
 
     wavelength = np.linspace(5000, 8000, 100)
-    g = gaussvel(wavelength, rest_wavelength.value, p)
+    g = gauss_vel(wavelength, rest_wavelength.value, p)
     obs = np.random.normal(g, .05)
     vw_oversampled = spectools.velocity_width(
         wavelength=wavelength, model=g, data=obs, rest_wavelength=rest_wavelength, oversample=15,


### PR DESCRIPTION
Since numpy version 1.22 the Fortran subroutines gaussvel and gaussshermitevel stopped working, with the following error message:

```
ValueError: elprofile.elprofile.gaussvel: failed to create array from the 3rd argument `p` -- 0-th dimension must be fixed to 1 but got 3
```

This was caused by problems in the definition of array dimensions in the Fortran subroutines, which is fixed by this pull request. 

Successful tests have been performed using Python 3.11 and Numpy 1.26.0.